### PR TITLE
JLRoutes Dependancy Fix

### DIFF
--- a/JLRoutes-EasyRouting.podspec
+++ b/JLRoutes-EasyRouting.podspec
@@ -99,5 +99,5 @@ Pod::Spec.new do |s|
 
   # Finally, specify any Pods that this Pod depends on.
   #
-  s.dependency 'JLRoutes', '<= 1.5'
+  s.dependency 'JLRoutes', '< 1.6'
 end

--- a/JLRoutes-EasyRouting.podspec
+++ b/JLRoutes-EasyRouting.podspec
@@ -99,5 +99,5 @@ Pod::Spec.new do |s|
 
   # Finally, specify any Pods that this Pod depends on.
   #
-  s.dependency 'JLRoutes', '~> 1.2'
+  s.dependency 'JLRoutes', '<= 1.5'
 end

--- a/podfile
+++ b/podfile
@@ -1,3 +1,3 @@
 platform :ios, '5.0'
-pod 'JLRoutes', '~> 1.2'
+pod 'JLRoutes', '<= 1.5'
 

--- a/podfile
+++ b/podfile
@@ -1,3 +1,3 @@
 platform :ios, '5.0'
-pod 'JLRoutes', '<= 1.5'
+pod 'JLRoutes', '< 1.6'
 


### PR DESCRIPTION
Our Extensions are not compatible with JLRoutes 1.6. Fixed the dependency to specify 1.5.\* 
